### PR TITLE
refactor: refactor bad smell InnerClassMayBeStatic

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkRecord.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerBulkRecord.java
@@ -16,8 +16,7 @@ import java.util.Map.Entry;
  * Abstract class that implements ISQLServerBulkRecord
  *
  */
-@SuppressWarnings("deprecation")
-abstract class SQLServerBulkRecord implements ISQLServerBulkRecord {
+@SuppressWarnings("deprecation")abstractclass SQLServerBulkRecord implements ISQLServerBulkRecord {
 
     /**
      * Update serialVersionUID when making changes to this file
@@ -27,7 +26,7 @@ abstract class SQLServerBulkRecord implements ISQLServerBulkRecord {
     /*
      * Class to represent the column metadata
      */
-    protected class ColumnMetadata {
+    protected static class ColumnMetadata {
         String columnName;
         int columnType;
         int precision;

--- a/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/SQLServerParameterMetaData.java
@@ -74,7 +74,8 @@ public final class SQLServerParameterMetaData implements ParameterMetaData {
         return traceID;
     }
 
-    /* Used for prepared statement meta data */
+    
+    static/* Used for prepared statement meta data */
     class QueryMeta {
         String parameterClassName = null;
         int parameterType = 0;


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## InnerClassMayBeStatic
Inner classes that do not reference their enclosing instances can be made static.
This prevents a common cause of memory leaks and uses less memory per instance of the class.

<!-- fingerprint:772300040 -->
<!-- fingerprint:140810126 -->
<!-- fingerprint:1091744688 -->
<!-- fingerprint:-1208902467 -->
<!-- fingerprint:499653777 -->
<!-- fingerprint:-1387718782 -->
<!-- fingerprint:2008690665 -->
<!-- fingerprint:-267747041 -->
<!-- fingerprint:135562131 -->
<!-- fingerprint:2141642343 -->
<!-- fingerprint:542610481 -->
<!-- fingerprint:-499610818 -->
# Repairing Code Style Issues
* InnerClassMayBeStatic (12)
